### PR TITLE
Melhorias nos exemplos de escolha-caso

### DIFF
--- a/ajuda/recursos/exemplos/estruturas_controle/desvio/escolha_caso/exemplo1.por
+++ b/ajuda/recursos/exemplos/estruturas_controle/desvio/escolha_caso/exemplo1.por
@@ -1,4 +1,5 @@
 inteiro numero
+leia(numero)
 escolha(numero)
 {
 	caso 1:
@@ -18,6 +19,7 @@ escolha(numero)
 }
 
 cadeia texto
+leia(texto)
 escolha(texto)
 {
 	caso "sim":

--- a/ajuda/recursos/exemplos/estruturas_controle/desvio/escolha_caso/exemplo2.por
+++ b/ajuda/recursos/exemplos/estruturas_controle/desvio/escolha_caso/exemplo2.por
@@ -2,7 +2,7 @@ programa
 {
 	funcao inicio()
 	{			  
-	inteiro valor=1
+		inteiro valor=1
 		escolha (valor)
 		{
 		caso 0:		//testa se o valor é igual a 0


### PR DESCRIPTION
As variáveis do exemplo não possuíam valores, considero que solicitando o valor do usuário fica mais claro a necessidade da escolha dos casos, pois não há como prever.